### PR TITLE
Dark mode for the settings modal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,36 @@
+{
+  "name": "stack-scripts",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "version": "1.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "typescript": "^4.2.4"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
+      "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    }
+  },
+  "dependencies": {
+    "typescript": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
+      "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
+      "dev": true
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,24 @@
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
+        "@types/jquery": "^3.5.5",
         "typescript": "^4.2.4"
       }
+    },
+    "node_modules/@types/jquery": {
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.5.tgz",
+      "integrity": "sha512-6RXU9Xzpc6vxNrS6FPPapN1SxSHgQ336WC6Jj/N8q30OiaBZ00l1GBgeP7usjVZPivSkGUfL1z/WW6TX989M+w==",
+      "dev": true,
+      "dependencies": {
+        "@types/sizzle": "*"
+      }
+    },
+    "node_modules/@types/sizzle": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.3.tgz",
+      "integrity": "sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ==",
+      "dev": true
     },
     "node_modules/typescript": {
       "version": "4.2.4",
@@ -26,6 +42,21 @@
     }
   },
   "dependencies": {
+    "@types/jquery": {
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.5.tgz",
+      "integrity": "sha512-6RXU9Xzpc6vxNrS6FPPapN1SxSHgQ336WC6Jj/N8q30OiaBZ00l1GBgeP7usjVZPivSkGUfL1z/WW6TX989M+w==",
+      "dev": true,
+      "requires": {
+        "@types/sizzle": "*"
+      }
+    },
+    "@types/sizzle": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.3.tgz",
+      "integrity": "sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ==",
+      "dev": true
+    },
     "typescript": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",

--- a/package.json
+++ b/package.json
@@ -1,22 +1,21 @@
 {
   "name": "stack-scripts",
-  "version": "1.0.0",
+  "version": "2.2.0",
   "description": "A collection of scripts for the Stack Exchange network",
-  "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Oaphi/stack-scripts.git"
+    "url": "git@github.com:SpectricSO/stack-scripts.git"
   },
   "keywords": [],
   "author": "Spectric",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/Oaphi/stack-scripts/issues"
+    "url": "https://github.com/SpectricSO/stack-scripts/issues"
   },
-  "homepage": "https://github.com/Oaphi/stack-scripts#readme",
+  "homepage": "https://github.com/SpectricSO/stack-scripts",
   "devDependencies": {
     "@types/jquery": "^3.5.5",
     "typescript": "^4.2.4"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "stack-scripts",
+  "version": "1.0.0",
+  "description": "A collection of scripts for the Stack Exchange network",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Oaphi/stack-scripts.git"
+  },
+  "keywords": [],
+  "author": "Spectric",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/Oaphi/stack-scripts/issues"
+  },
+  "homepage": "https://github.com/Oaphi/stack-scripts#readme"
+}

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "homepage": "https://github.com/Oaphi/stack-scripts#readme",
   "devDependencies": {
+    "@types/jquery": "^3.5.5",
     "typescript": "^4.2.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,5 +16,8 @@
   "bugs": {
     "url": "https://github.com/Oaphi/stack-scripts/issues"
   },
-  "homepage": "https://github.com/Oaphi/stack-scripts#readme"
+  "homepage": "https://github.com/Oaphi/stack-scripts#readme",
+  "devDependencies": {
+    "typescript": "^4.2.4"
+  }
 }

--- a/scripts/focus-mode/v2.2/script.js
+++ b/scripts/focus-mode/v2.2/script.js
@@ -11,18 +11,107 @@
 
 (function () {
     'use strict';
-    $(document).ready(function () {
-        function addDependencies(){
-            var roboto  = document.createElement("link");
-            roboto.rel="stylesheet";
-            roboto.href="https://fonts.googleapis.com/css?family=Roboto&display=swap";
+
+    /**
+     * @summary converts ruleset into a string
+     * @param {{ [x:string]: string | number }} ruleset
+     * @returns {string}
+     */
+    function rulesetToString(ruleset) {
+        var output = "";
+        for (var ruleName in ruleset) {
+            if (!Object.hasOwnProperty.call(ruleset, ruleName)) continue;
+            output += ruleName + ":" + ruleset[ruleName] + "; ";
+        }
+        return output;
+    }
+
+    /**
+     * @summary converts style object into a string
+     * @param {{ [x: string]: { [x:string]: string | number } }} styleObj
+     * @returns {string}
+     */
+    function prepareStyle(styleObj) {
+        var output = "";
+        for (var selector in styleObj) {
+            if (!Object.hasOwnProperty.call(styleObj, selector)) continue;
+            output += " " + selector + "{" + rulesetToString(styleObj[selector]) + "}";
+
+        }
+        return output;
+    }
+
+    /**
+     * @summary converts settings style object to string
+     * @returns {string}
+     */
+    function prepareSettingsStyle() {
+        var style = document.createElement("style");
+        var rules = {
+            ".stack-focus-container": {
+                "pointer-events": "none",
+                "z-index": 100000,
+                "display": "flex",
+                "align-items": "center",
+                "justify-content": "center",
+                "height": "100%",
+                "width": "100%",
+                "position": "fixed",
+                "top": 0,
+                "left": 0,
+            },
+
+            ".stack-focus": {
+                "pointer-events": "all",
+                "width": "700px",
+                "height": "fit-content",
+                "background-color": "var(--white)",
+                "z-index": 10000000,
+                "box-shadow": "0 0 3px black",
+                "border-radius": "5px",
+                "padding": "2em",
+                "font-family": "Roboto"
+            },
+
+            ".stack-focus .stack-focus-option": {
+                "position": "relative"
+            },
+
+            ".stack-focus-option p": {
+                "position": "absolute",
+                "top": "5px"
+            },
+
+            ".stack-focus .input-group .f-radio-toggle": {
+                "margin-left": "auto"
+            },
+
+            ".stack-focus h1": {
+                "margin-bottom": "5px"
+            }
+        };
+
+        style.textContent = prepareStyle(rules);
+        return style.outerHTML;
+    }
+
+    $(function () {
+
+        function addDependencies() {
+            var roboto = document.createElement("link");
+            roboto.rel = "stylesheet";
+            roboto.href = "https://fonts.googleapis.com/css?family=Roboto&display=swap";
             $(document.head).append(roboto);
         }
+
         addDependencies();
+
         String.prototype.includes = function (e) {
             return this.indexOf(e) != -1;
-        }
+        };
+
         var isInstalled = localStorage.getItem("stack-focus-preferences") != null;
+
         if (!isInstalled) {
             localStorage.setItem("stack-focus-preferences", JSON.stringify({
                 "findajob": "show",
@@ -33,18 +122,23 @@
                 "hotnetworkq": "show"
             }));
         }
+
         try {
             var preferences = JSON.parse(localStorage.getItem("stack-focus-preferences"));
         } catch (err) {
             console.error("%cStack Focus storage has been corrupted. Enter %clocalStorage.removeItem('stack-focus-preferences');%c into the console to recalibrate storage.", "", "font-family:Courier", "");
         }
-        const html = '<style>.stack-focus-container{pointer-events:none;z-index:100000;display: flex;align-items: center;justify-content: center;height: 100%;width: 100%;position: fixed;top: 0;left: 0;}.stack-focus{pointer-events:all;width: 700px; height: fit-content; background-color: white; z-index: 10000000; box-shadow: 0 0 3px black; border-radius: 5px; padding: 2em; font-family: Roboto}.stack-focus .stack-focus-option{position: relative}.stack-focus-option p{position: absolute; top: 5px}.stack-focus .input-group .f-radio-toggle{margin-left: auto}.stack-focus h1{margin-bottom: 5px;}</style> <div class="stack-focus-container"> <div class="stack-focus"> <h1>Stack Focus Mode</h1> <h3>By: <a href="https://stackoverflow.com/users/14251221">Spectric</a></h3> <div> <div class="stack-focus-option"> <p>Left sidebar Find a Job category:</p><div class="input-group"> <div class="grid f-radio-toggle _muted"> <div class="grid--cell"> <input class="js-subscribe" type="radio" name="stack-focus-1" id="left_sidebar_findajob_on" checked=""> <label for="left_sidebar_findajob_on" class="f-label">Show</label></div><div class="grid--cell"> <input class="_off js-unsubscribe " type="radio" name="stack-focus-1" id="left_sidebar_findajob_off"> <label for="left_sidebar_findajob_off" class="f-label">Hide</label></div></div></div></div><div class="stack-focus-option"> <p>Left sidebar Teams advertisement:</p><div class="input-group"> <div class="grid f-radio-toggle _muted"> <div class="grid--cell"> <input class="js-subscribe" type="radio" name="stack-focus-2" id="left_sidebar_teams_on" checked=""> <label for="left_sidebar_teams_on" class="f-label">Show</label></div><div class="grid--cell"> <input class="_off js-unsubscribe " type="radio" name="stack-focus-2" id="left_sidebar_teams_off"> <label for="left_sidebar_teams_off" class="f-label">Hide</label></div></div></div></div><div class="stack-focus-option"> <p>Overflow Blog + Featured on Meta + Hot Meta Posts:</p><div class="input-group"> <div class="grid f-radio-toggle _muted"> <div class="grid--cell"> <input class="js-subscribe" type="radio" name="stack-focus-3" id="right_sidebar_oblock_on" checked=""> <label for="right_sidebar_oblock_on" class="f-label">Show</label></div><div class="grid--cell"> <input class="_off js-unsubscribe " type="radio" name="stack-focus-3" id="right_sidebar_oblock_off"> <label for="right_sidebar_oblock_off" class="f-label">Hide</label></div></div></div></div><div class="stack-focus-option"> <p>Linked Posts:</p><div class="input-group"> <div class="grid f-radio-toggle _muted"> <div class="grid--cell"> <input class="js-subscribe" type="radio" name="stack-focus-4" id="right_sidebar_linkedposts_on" checked=""> <label for="right_sidebar_linkedposts_on" class="f-label">Show</label></div><div class="grid--cell"> <input class="_off js-unsubscribe " type="radio" name="stack-focus-4" id="right_sidebar_linkedposts_off"> <label for="right_sidebar_linkedposts_off" class="f-label">Hide</label></div></div></div></div><div class="stack-focus-option"> <p>Related Posts:</p><div class="input-group"> <div class="grid f-radio-toggle _muted"> <div class="grid--cell"> <input class="js-subscribe" type="radio" name="stack-focus-5" id="right_sidebar_relatedposts_on" checked=""> <label for="right_sidebar_relatedposts_on" class="f-label">Show</label></div><div class="grid--cell"> <input class="_off js-unsubscribe " type="radio" name="stack-focus-5" id="right_sidebar_relatedposts_off"> <label for="right_sidebar_relatedposts_off" class="f-label">Hide</label></div></div></div></div><div class="stack-focus-option"> <p>Hot Network Questions</p><div class="input-group"> <div class="grid f-radio-toggle _muted"> <div class="grid--cell"> <input class="js-subscribe" type="radio" name="stack-focus-6" id="right_sidebar_hotnetwork_on" checked=""> <label for="right_sidebar_hotnetwork_on" class="f-label">Show</label></div><div class="grid--cell"> <input class="_off js-unsubscribe " type="radio" name="stack-focus-6" id="right_sidebar_hotnetwork_off"> <label for="right_sidebar_hotnetwork_off" class="f-label">Hide</label></div></div></div></div></div></div></div>';
+
+        const html = prepareSettingsStyle() + '<div class="stack-focus-container"> <div class="stack-focus"> <h1>Stack Focus Mode</h1> <h3>By: <a href="https://stackoverflow.com/users/14251221">Spectric</a></h3> <div> <div class="stack-focus-option"> <p>Left sidebar Find a Job category:</p><div class="input-group"> <div class="grid f-radio-toggle _muted"> <div class="grid--cell"> <input class="js-subscribe" type="radio" name="stack-focus-1" id="left_sidebar_findajob_on" checked=""> <label for="left_sidebar_findajob_on" class="f-label">Show</label></div><div class="grid--cell"> <input class="_off js-unsubscribe " type="radio" name="stack-focus-1" id="left_sidebar_findajob_off"> <label for="left_sidebar_findajob_off" class="f-label">Hide</label></div></div></div></div><div class="stack-focus-option"> <p>Left sidebar Teams advertisement:</p><div class="input-group"> <div class="grid f-radio-toggle _muted"> <div class="grid--cell"> <input class="js-subscribe" type="radio" name="stack-focus-2" id="left_sidebar_teams_on" checked=""> <label for="left_sidebar_teams_on" class="f-label">Show</label></div><div class="grid--cell"> <input class="_off js-unsubscribe " type="radio" name="stack-focus-2" id="left_sidebar_teams_off"> <label for="left_sidebar_teams_off" class="f-label">Hide</label></div></div></div></div><div class="stack-focus-option"> <p>Overflow Blog + Featured on Meta + Hot Meta Posts:</p><div class="input-group"> <div class="grid f-radio-toggle _muted"> <div class="grid--cell"> <input class="js-subscribe" type="radio" name="stack-focus-3" id="right_sidebar_oblock_on" checked=""> <label for="right_sidebar_oblock_on" class="f-label">Show</label></div><div class="grid--cell"> <input class="_off js-unsubscribe " type="radio" name="stack-focus-3" id="right_sidebar_oblock_off"> <label for="right_sidebar_oblock_off" class="f-label">Hide</label></div></div></div></div><div class="stack-focus-option"> <p>Linked Posts:</p><div class="input-group"> <div class="grid f-radio-toggle _muted"> <div class="grid--cell"> <input class="js-subscribe" type="radio" name="stack-focus-4" id="right_sidebar_linkedposts_on" checked=""> <label for="right_sidebar_linkedposts_on" class="f-label">Show</label></div><div class="grid--cell"> <input class="_off js-unsubscribe " type="radio" name="stack-focus-4" id="right_sidebar_linkedposts_off"> <label for="right_sidebar_linkedposts_off" class="f-label">Hide</label></div></div></div></div><div class="stack-focus-option"> <p>Related Posts:</p><div class="input-group"> <div class="grid f-radio-toggle _muted"> <div class="grid--cell"> <input class="js-subscribe" type="radio" name="stack-focus-5" id="right_sidebar_relatedposts_on" checked=""> <label for="right_sidebar_relatedposts_on" class="f-label">Show</label></div><div class="grid--cell"> <input class="_off js-unsubscribe " type="radio" name="stack-focus-5" id="right_sidebar_relatedposts_off"> <label for="right_sidebar_relatedposts_off" class="f-label">Hide</label></div></div></div></div><div class="stack-focus-option"> <p>Hot Network Questions</p><div class="input-group"> <div class="grid f-radio-toggle _muted"> <div class="grid--cell"> <input class="js-subscribe" type="radio" name="stack-focus-6" id="right_sidebar_hotnetwork_on" checked=""> <label for="right_sidebar_hotnetwork_on" class="f-label">Show</label></div><div class="grid--cell"> <input class="_off js-unsubscribe " type="radio" name="stack-focus-6" id="right_sidebar_hotnetwork_off"> <label for="right_sidebar_hotnetwork_off" class="f-label">Hide</label></div></div></div></div></div></div></div>';
+
         function setup() {
             $(document.body).append(html);
         }
+
         function check(jqueryCheckbox) {
             jqueryCheckbox.prop("checked", true);
         }
+
         function calibrate() {
             if (preferences.findajob != "show") {
                 $($('li .fs-fine').get(1)).hide();
@@ -66,7 +160,7 @@
                 $('.s-sidebarwidget[data-tracker="cb=1"]').hide();
                 check($('#right_sidebar_oblock_off'));
             } else {
-                $('.s-sidebarwidget[data-tracker="cb=1"]').show()
+                $('.s-sidebarwidget[data-tracker="cb=1"]').show();
             }
             if (preferences.linked != "show") {
                 $('.sidebar-linked').hide();
@@ -87,9 +181,11 @@
                 $('#hot-network-questions').show();
             }
         }
+
         function invert(s) {
             return (s == "show" ? "hide" : "show");
         }
+
         function updateStorage(id) {
             if (id.includes('left_sidebar_findajob')) {
                 preferences.findajob = invert(preferences.findajob);
@@ -114,25 +210,27 @@
             preferences = JSON.parse(stringified);
             console.log(preferences);
         }
+
         function logic() {
             var modal = $('.stack-focus');
             modal.hide();
             $('input', modal).on('click', function () {
                 updateStorage($(this).attr('id'));
                 calibrate();
-            })
+            });
             $(document).on('keyup', function (e) {
                 var evt = window.event || e;
                 if (evt.keyCode == 81 && evt.ctrlKey) {
                     console.log(modal);
                     modal.fadeToggle();
                 }
-            })
+            });
         }
+
         setup();
         calibrate();
         logic();
-    })
+    });
 })();
 
 /*

--- a/scripts/focus-mode/v2.2/script.js
+++ b/scripts/focus-mode/v2.2/script.js
@@ -186,25 +186,32 @@
             return (s == "show" ? "hide" : "show");
         }
 
+        /**
+         * @summary updates preferences
+         * @param {string} id
+         */
         function updateStorage(id) {
-            if (id.includes('left_sidebar_findajob')) {
-                preferences.findajob = invert(preferences.findajob);
+            var invertMap = [
+                ["left_sidebar_findajob", "findajob"],
+                ["left_sidebar_teams", "teamsadvert"],
+                ["right_sidebar_oblock", "oblock"],
+                ["right_sidebar_linkedposts", "linked"],
+                ["right_sidebar_relatedposts", "related"],
+                ["right_sidebar_hotnetwork", "hotnetworkq"]
+            ];
+
+            var len = invertMap.length;
+
+            for (var i = 0; i < len; i++) {
+                var pair = invertMap[i];
+                var toCheck = pair[0];
+                var toInvert = pair[1];
+
+                if (!id.includes(toCheck)) continue;
+
+                preferences[toInvert] = invert(preferences[toInvert]);
             }
-            if (id.includes('left_sidebar_teams')) {
-                preferences.teamsadvert = invert(preferences.teamsadvert);
-            }
-            if (id.includes('right_sidebar_oblock')) {
-                preferences.oblock = invert(preferences.oblock);
-            }
-            if (id.includes('right_sidebar_linkedposts')) {
-                preferences.linked = invert(preferences.linked);
-            }
-            if (id.includes('right_sidebar_relatedposts')) {
-                preferences.related = invert(preferences.related);
-            }
-            if (id.includes('right_sidebar_hotnetwork')) {
-                preferences.hotnetworkq = invert(preferences.hotnetworkq);
-            }
+
             let stringified = JSON.stringify(preferences);
             localStorage.setItem("stack-focus-preferences", stringified);
             preferences = JSON.parse(stringified);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "lib": ["ESNext", "DOM"],
+    "noEmit": true,
+    "module": "none"
+  }
+}


### PR DESCRIPTION
The PR introduces dark mode for settings modal as well as a couple of utilities for converting JS objects to style strings. The next version could go for the `CSSStyleSheet` interface which would likely be more maintainable.

The PR also includes an improvement to the `updateStorage` utility that avoids repeating `if` constructs.

P.s. Minified version not included. If you are up for adding a build step to the repository - can do.